### PR TITLE
Add SharedPreference inject example.

### DIFF
--- a/app/src/main/java/com/github/tonytangandroid/daggertutorial/MainActivity.java
+++ b/app/src/main/java/com/github/tonytangandroid/daggertutorial/MainActivity.java
@@ -1,6 +1,7 @@
 package com.github.tonytangandroid.daggertutorial;
 
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.widget.TextView;
@@ -12,13 +13,18 @@ public class MainActivity extends AppCompatActivity {
     @Inject
     Context injectedContext;
 
+    @Inject
+    SharedPreferences injectedSharedPreferences;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         ((TutorialApplication) getApplication()).activityInjector().inject(this);
         setContentView(R.layout.activity_main);
         TextView tvAppName = findViewById(R.id.tv_app_name);
+        TextView tvSharedPreference = findViewById(R.id.tv_shared_preferences);
         tvAppName.setText(injectedContext.getText(R.string.app_name));
+        tvSharedPreference.setText(injectedSharedPreferences.getString("NonExistedKey", "Default  value"));
 
     }
 }

--- a/app/src/main/java/com/github/tonytangandroid/daggertutorial/dagger/ApplicationComponent.java
+++ b/app/src/main/java/com/github/tonytangandroid/daggertutorial/dagger/ApplicationComponent.java
@@ -1,14 +1,18 @@
 package com.github.tonytangandroid.daggertutorial.dagger;
 
 import android.content.Context;
+import android.content.SharedPreferences;
 
 import com.github.tonytangandroid.daggertutorial.dagger.module.ApplicationModule;
+import com.github.tonytangandroid.daggertutorial.dagger.module.SharedPreferenceModule;
 
 import dagger.Component;
 
-@Component(modules = {ApplicationModule.class})
+@Component(modules = {ApplicationModule.class, SharedPreferenceModule.class})
 public interface ApplicationComponent {
 
     Context context();
+
+    SharedPreferences sharedPreferences();
 
 }

--- a/app/src/main/java/com/github/tonytangandroid/daggertutorial/dagger/module/SharedPreferenceModule.java
+++ b/app/src/main/java/com/github/tonytangandroid/daggertutorial/dagger/module/SharedPreferenceModule.java
@@ -1,0 +1,18 @@
+package com.github.tonytangandroid.daggertutorial.dagger.module;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
+
+import dagger.Module;
+import dagger.Provides;
+
+@Module
+public class SharedPreferenceModule {
+
+    @Provides
+    SharedPreferences provideSharedPreferences(Context context) {
+        return PreferenceManager.getDefaultSharedPreferences(context);
+    }
+
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,16 +1,61 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout
+<LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:layout_margin="16dp"
+    android:orientation="vertical"
     tools:context="com.github.tonytangandroid.daggertutorial.MainActivity">
 
-    <TextView
-        android:id="@+id/tv_app_name"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        android:text="Hello World!"/>
 
-</FrameLayout>
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="16dp"
+        android:orientation="horizontal">
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:layout_weight="2"
+            android:text="value from context:"
+            tools:ignore="HardcodedText"/>
+
+        <TextView
+            android:id="@+id/tv_app_name"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:layout_weight="1"
+            tools:ignore="HardcodedText"/>
+
+    </LinearLayout>
+
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="16dp"
+        android:orientation="horizontal">
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:layout_weight="2"
+            android:text="value from shared preferences:"
+            tools:ignore="HardcodedText"/>
+
+        <TextView
+            android:id="@+id/tv_shared_preferences"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:layout_weight="1"
+            tools:ignore="HardcodedText"/>
+
+    </LinearLayout>
+
+</LinearLayout>


### PR DESCRIPTION
 1, Add a shared preference module.
 2, Include the shared preference module in application component.
 3, Expose the shared preference interface.
 4, Create a Activity component which depends on the application component.
 5, Inject the activity to initial the shared preference and context in the main activity.