### PR TITLE
Add a named annotation module to demonstrate the @Named annotation.

### DIFF
--- a/app/src/main/java/com/github/tonytangandroid/daggertutorial/MainActivity.java
+++ b/app/src/main/java/com/github/tonytangandroid/daggertutorial/MainActivity.java
@@ -7,6 +7,7 @@ import android.support.v7.app.AppCompatActivity;
 import android.widget.TextView;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 
 public class MainActivity extends AppCompatActivity {
 
@@ -16,6 +17,20 @@ public class MainActivity extends AppCompatActivity {
     @Inject
     SharedPreferences injectedSharedPreferences;
 
+    @Named("app_name_from_named_annotation")
+    @Inject
+    String appName;
+
+    @Named("shared_preference_value")
+    @Inject
+    String sharedPreferenceValue;
+
+    @Inject
+    String nameWithoutAnnotation;
+
+    @Inject
+    boolean debug;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -23,8 +38,12 @@ public class MainActivity extends AppCompatActivity {
         setContentView(R.layout.activity_main);
         TextView tvAppName = findViewById(R.id.tv_app_name);
         TextView tvSharedPreference = findViewById(R.id.tv_shared_preferences);
-        tvAppName.setText(injectedContext.getText(R.string.app_name));
-        tvSharedPreference.setText(injectedSharedPreferences.getString("NonExistedKey", "Default  value"));
+        TextView tvNameWithoutNamedAnnotation = findViewById(R.id.tv_name_without_annotation);
+        TextView tvDebug = findViewById(R.id.tv_debug);
+        tvAppName.setText(appName);
+        tvSharedPreference.setText(sharedPreferenceValue);
+        tvNameWithoutNamedAnnotation.setText(nameWithoutAnnotation);
+        tvDebug.setText(String.valueOf(debug));
 
     }
 }

--- a/app/src/main/java/com/github/tonytangandroid/daggertutorial/dagger/ApplicationComponent.java
+++ b/app/src/main/java/com/github/tonytangandroid/daggertutorial/dagger/ApplicationComponent.java
@@ -4,15 +4,28 @@ import android.content.Context;
 import android.content.SharedPreferences;
 
 import com.github.tonytangandroid.daggertutorial.dagger.module.ApplicationModule;
+import com.github.tonytangandroid.daggertutorial.dagger.module.NamedAnnotationModule;
 import com.github.tonytangandroid.daggertutorial.dagger.module.SharedPreferenceModule;
+
+import javax.inject.Named;
 
 import dagger.Component;
 
-@Component(modules = {ApplicationModule.class, SharedPreferenceModule.class})
+@Component(modules = {ApplicationModule.class, SharedPreferenceModule.class, NamedAnnotationModule.class})
 public interface ApplicationComponent {
 
     Context context();
 
     SharedPreferences sharedPreferences();
+
+    @Named("app_name_from_named_annotation")
+    String appName();
+
+    @Named("shared_preference_value")
+    String defaultSharedPreferenceValue();
+
+    String nameWithoutNamedAnnotation();
+
+    boolean debug();
 
 }

--- a/app/src/main/java/com/github/tonytangandroid/daggertutorial/dagger/module/NamedAnnotationModule.java
+++ b/app/src/main/java/com/github/tonytangandroid/daggertutorial/dagger/module/NamedAnnotationModule.java
@@ -1,0 +1,36 @@
+package com.github.tonytangandroid.daggertutorial.dagger.module;
+
+import com.github.tonytangandroid.daggertutorial.BuildConfig;
+
+import javax.inject.Named;
+
+import dagger.Module;
+import dagger.Provides;
+
+@Module
+public class NamedAnnotationModule {
+
+    @Provides
+    @Named("app_name_from_named_annotation")
+    String provideAppName() {
+        return "This is a value from named annotation";
+    }
+
+    @Provides
+    String provideValueWithoutAnnotationAppName() {
+        return "This is a value without named annotation";
+    }
+
+    @Provides
+    boolean debug() {
+        return BuildConfig.DEBUG;
+    }
+
+
+    @Provides
+    @Named("shared_preference_value")
+    String provideSharedPreferenceValue() {
+        return "This is a shared preference value";
+    }
+
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -58,4 +58,52 @@
 
     </LinearLayout>
 
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="16dp"
+        android:orientation="horizontal">
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:layout_weight="2"
+            android:text="value from shared preferences:"
+            tools:ignore="HardcodedText"/>
+
+        <TextView
+            android:id="@+id/tv_name_without_annotation"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:layout_weight="1"
+            tools:ignore="HardcodedText"/>
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="16dp"
+        android:orientation="horizontal">
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:layout_weight="2"
+            android:text="Debug:"
+            tools:ignore="HardcodedText"/>
+
+        <TextView
+            android:id="@+id/tv_debug"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:layout_weight="1"
+            tools:ignore="HardcodedText"/>
+
+    </LinearLayout>
+
 </LinearLayout>


### PR DESCRIPTION
Add a named annotation module to demonstrate the @Named annotation.

1, If you only have one value for the same type of data, you could just provide it without named annotation.

In the example, we provide a boolean value from NamedAnnotationModule to inject into the MainActivity directly without any named annotation.

2, If you have more than one value for the same type data, you need to specify the named value.

In the example, we provide three different String value from NamedAnnotationModule to inject into the MainActivity.

 Please pay attention that if you did not specify the annotation, the default value will be used.