### PR TITLE
Add a ApplicationScope to create on ApplicationComponent.java

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.application'
+apply plugin: 'com.jakewharton.hugo'
 
 android {
     compileSdkVersion 27

--- a/app/src/main/java/com/github/tonytangandroid/daggertutorial/GetMessageUseCase.java
+++ b/app/src/main/java/com/github/tonytangandroid/daggertutorial/GetMessageUseCase.java
@@ -5,20 +5,23 @@ import javax.inject.Named;
 
 public class GetMessageUseCase {
 
-    private final PremiumDataRepository premiumDataRepository;
+    private final UserRepository userRepository;
+    private final PremiumRepository premiumRepository;
     private final String messageForPremium;
     private final String messageForNonePremium;
 
     @Inject
-    public GetMessageUseCase(PremiumDataRepository premiumDataRepository,
+    public GetMessageUseCase(UserRepository userRepository, PremiumRepository premiumRepository,
                              @Named("premium_message") String messageForPremium,
                              @Named("none_premium_message") String messageForNonePremium) {
-        this.premiumDataRepository = premiumDataRepository;
+        this.userRepository = userRepository;
+        this.premiumRepository = premiumRepository;
         this.messageForPremium = messageForPremium;
         this.messageForNonePremium = messageForNonePremium;
     }
 
     public String retrieveMessage() {
-        return premiumDataRepository.isPremiumUser() ? messageForPremium : messageForNonePremium;
+        return "Hello " + userRepository.getUserName() + ","
+                + (premiumRepository.isPremiumUser() ? messageForPremium : messageForNonePremium);
     }
 }

--- a/app/src/main/java/com/github/tonytangandroid/daggertutorial/MainActivity.java
+++ b/app/src/main/java/com/github/tonytangandroid/daggertutorial/MainActivity.java
@@ -32,6 +32,10 @@ public class MainActivity extends AppCompatActivity implements MainView {
 
     @Inject
     MainPresenter mainPresenter;
+
+    @Inject
+    MainPresenter mainPresenter2;
+
     @Inject
     boolean debug;
     private TextView tvMessage;
@@ -53,6 +57,7 @@ public class MainActivity extends AppCompatActivity implements MainView {
         tvDebug.setText(String.valueOf(debug));
 
         mainPresenter.create();
+        mainPresenter2.create();
 
     }
 

--- a/app/src/main/java/com/github/tonytangandroid/daggertutorial/PremiumDataRepository.java
+++ b/app/src/main/java/com/github/tonytangandroid/daggertutorial/PremiumDataRepository.java
@@ -4,10 +4,13 @@ import android.content.SharedPreferences;
 
 import javax.inject.Inject;
 
-public class PremiumDataRepository {
+import hugo.weaving.DebugLog;
+
+public class PremiumDataRepository implements PremiumRepository {
 
     private final SharedPreferences sharedPreferences;
 
+    @DebugLog
     @Inject
     public PremiumDataRepository(SharedPreferences sharedPreferences) {
         this.sharedPreferences = sharedPreferences;

--- a/app/src/main/java/com/github/tonytangandroid/daggertutorial/PremiumRepository.java
+++ b/app/src/main/java/com/github/tonytangandroid/daggertutorial/PremiumRepository.java
@@ -1,0 +1,6 @@
+package com.github.tonytangandroid.daggertutorial;
+
+public interface PremiumRepository {
+
+    boolean isPremiumUser();
+}

--- a/app/src/main/java/com/github/tonytangandroid/daggertutorial/UserDataRepository.java
+++ b/app/src/main/java/com/github/tonytangandroid/daggertutorial/UserDataRepository.java
@@ -1,0 +1,19 @@
+package com.github.tonytangandroid.daggertutorial;
+
+import javax.inject.Inject;
+
+import hugo.weaving.DebugLog;
+
+public class UserDataRepository implements UserRepository {
+
+    @DebugLog
+    @Inject
+    public UserDataRepository() {
+
+    }
+
+    @Override
+    public String getUserName() {
+        return "TonyTang";
+    }
+}

--- a/app/src/main/java/com/github/tonytangandroid/daggertutorial/UserRepository.java
+++ b/app/src/main/java/com/github/tonytangandroid/daggertutorial/UserRepository.java
@@ -1,0 +1,6 @@
+package com.github.tonytangandroid.daggertutorial;
+
+public interface UserRepository {
+
+    String getUserName();
+}

--- a/app/src/main/java/com/github/tonytangandroid/daggertutorial/dagger/ApplicationComponent.java
+++ b/app/src/main/java/com/github/tonytangandroid/daggertutorial/dagger/ApplicationComponent.java
@@ -4,14 +4,19 @@ import android.app.Application;
 
 import com.github.tonytangandroid.daggertutorial.TutorialApplication;
 import com.github.tonytangandroid.daggertutorial.dagger.module.ApplicationModule;
+import com.github.tonytangandroid.daggertutorial.dagger.module.DataBindModule;
+import com.github.tonytangandroid.daggertutorial.dagger.module.DataProviderModule;
 import com.github.tonytangandroid.daggertutorial.dagger.module.NamedAnnotationModule;
 import com.github.tonytangandroid.daggertutorial.dagger.module.SharedPreferenceModule;
+import com.github.tonytangandroid.daggertutorial.dagger.scope.ApplicationScope;
 
 import dagger.BindsInstance;
 import dagger.Component;
 import dagger.android.AndroidInjectionModule;
 
+@ApplicationScope
 @Component(modules = {ApplicationModule.class, SharedPreferenceModule.class, NamedAnnotationModule.class,
+        DataProviderModule.class, DataBindModule.class,
         AndroidInjectionModule.class, ActivityInjector.class})
 public interface ApplicationComponent {
 

--- a/app/src/main/java/com/github/tonytangandroid/daggertutorial/dagger/module/DataBindModule.java
+++ b/app/src/main/java/com/github/tonytangandroid/daggertutorial/dagger/module/DataBindModule.java
@@ -1,0 +1,17 @@
+package com.github.tonytangandroid.daggertutorial.dagger.module;
+
+import com.github.tonytangandroid.daggertutorial.PremiumDataRepository;
+import com.github.tonytangandroid.daggertutorial.PremiumRepository;
+import com.github.tonytangandroid.daggertutorial.dagger.scope.ApplicationScope;
+
+import dagger.Binds;
+import dagger.Module;
+
+@Module
+public abstract class DataBindModule {
+
+    @ApplicationScope
+    @Binds
+    abstract PremiumRepository providePremiumRepository(PremiumDataRepository premiumDataRepository);
+
+}

--- a/app/src/main/java/com/github/tonytangandroid/daggertutorial/dagger/module/DataProviderModule.java
+++ b/app/src/main/java/com/github/tonytangandroid/daggertutorial/dagger/module/DataProviderModule.java
@@ -1,0 +1,17 @@
+package com.github.tonytangandroid.daggertutorial.dagger.module;
+
+import com.github.tonytangandroid.daggertutorial.UserDataRepository;
+import com.github.tonytangandroid.daggertutorial.UserRepository;
+
+import dagger.Module;
+import dagger.Provides;
+
+@Module
+public class DataProviderModule {
+
+    @Provides
+    UserRepository provideUserRepositoryInterface() {
+        return new UserDataRepository();
+    }
+
+}

--- a/app/src/main/java/com/github/tonytangandroid/daggertutorial/dagger/scope/ApplicationScope.java
+++ b/app/src/main/java/com/github/tonytangandroid/daggertutorial/dagger/scope/ApplicationScope.java
@@ -1,0 +1,11 @@
+package com.github.tonytangandroid.daggertutorial.dagger.scope;
+
+import java.lang.annotation.Retention;
+
+import javax.inject.Scope;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Scope
+@Retention(RUNTIME)
+public @interface ApplicationScope {}

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,8 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.1'
-        
+        classpath 'com.jakewharton.hugo:hugo-plugin:1.2.1'
+
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
Add a ApplicationScope to create on ApplicationComponent.java, which would make it possible that all provided dependencies will be a singleton in the application level if it has been annotated with @ApplicationScope.

In DataBindModule.java, we annotated PremiumRepository as ApplicationScope.
This will mean that PremiumRepository will server as a singleton.
And its construct method will be only called once. You cold verify it by the huge log printed in the console.

In DataProviderModule.java, UserRepository was not annotated as Application Scope, it is not a singleton. So it will be created as many times as it injected.