### PR TITLE
Add a tile service which only exists in Android 24 or later to demonstrate a problem.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'com.android.support:appcompat-v7:27.0.2'
     implementation 'com.google.dagger:dagger:2.14.1'
+    implementation 'com.jakewharton.timber:timber:4.6.0'
     annotationProcessor 'com.google.dagger:dagger-compiler:2.14.1'
     implementation 'com.google.dagger:dagger-android:2.14.1'
     annotationProcessor 'com.google.dagger:dagger-android-processor:2.14.1'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,6 +20,18 @@
         <service
             android:name=".DemoService"
             android:exported="false"/>
+
+        <service
+            android:name=".QuickTileService"
+            android:icon="@drawable/ic_launcher_foreground"
+            android:label="@string/app_name"
+            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
+            <intent-filter>
+                <action android:name="android.service.quicksettings.action.QS_TILE"/>
+            </intent-filter>
+        </service>
+
+
     </application>
 
 </manifest>

--- a/app/src/main/java/com/github/tonytangandroid/daggertutorial/DemoService.java
+++ b/app/src/main/java/com/github/tonytangandroid/daggertutorial/DemoService.java
@@ -5,7 +5,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.IBinder;
 import android.support.annotation.Nullable;
-import android.widget.Toast;
 
 import javax.inject.Inject;
 
@@ -25,7 +24,6 @@ public class DemoService extends Service {
     public void onCreate() {
         super.onCreate();
         AndroidInjection.inject(this);
-        Toast.makeText(this, "service toast :" + injectedStringValue, Toast.LENGTH_SHORT).show();
     }
 
     @Nullable

--- a/app/src/main/java/com/github/tonytangandroid/daggertutorial/QuickTileService.java
+++ b/app/src/main/java/com/github/tonytangandroid/daggertutorial/QuickTileService.java
@@ -1,0 +1,54 @@
+package com.github.tonytangandroid.daggertutorial;
+
+import android.os.Build;
+import android.service.quicksettings.TileService;
+import android.support.annotation.RequiresApi;
+import android.widget.Toast;
+
+import javax.inject.Inject;
+
+import dagger.android.AndroidInjection;
+import timber.log.Timber;
+
+/**
+ * Created by ztang on 2/8/18.
+ */
+@RequiresApi(api = Build.VERSION_CODES.N)
+public class QuickTileService extends TileService {
+
+    @Inject
+    String injectedString;
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        AndroidInjection.inject(this);
+    }
+
+    @Override
+    public void onTileAdded() {
+        Timber.d("Tile added");
+    }
+
+    @Override
+    public void onStartListening() {
+        Timber.d("Start listening");
+    }
+
+    @Override
+    public void onClick() {
+        Toast.makeText(this, "toast from tile :" + injectedString, Toast.LENGTH_SHORT).show();
+
+    }
+
+    @Override
+    public void onStopListening() {
+        Timber.d("Stop Listening");
+    }
+
+    @Override
+    public void onTileRemoved() {
+        Timber.d("Tile removed");
+    }
+
+}

--- a/app/src/main/java/com/github/tonytangandroid/daggertutorial/TutorialApplication.java
+++ b/app/src/main/java/com/github/tonytangandroid/daggertutorial/TutorialApplication.java
@@ -12,6 +12,7 @@ import dagger.android.AndroidInjector;
 import dagger.android.DispatchingAndroidInjector;
 import dagger.android.HasActivityInjector;
 import dagger.android.HasServiceInjector;
+import timber.log.Timber;
 
 public class TutorialApplication extends Application implements HasActivityInjector, HasServiceInjector {
 
@@ -25,6 +26,7 @@ public class TutorialApplication extends Application implements HasActivityInjec
     public void onCreate() {
         super.onCreate();
         DaggerApplicationComponent.builder().application(this).build().inject(this);
+        Timber.plant(new Timber.DebugTree());
     }
 
     @Override

--- a/app/src/main/java/com/github/tonytangandroid/daggertutorial/dagger/ServiceInjector.java
+++ b/app/src/main/java/com/github/tonytangandroid/daggertutorial/dagger/ServiceInjector.java
@@ -1,6 +1,7 @@
 package com.github.tonytangandroid.daggertutorial.dagger;
 
 import com.github.tonytangandroid.daggertutorial.DemoService;
+import com.github.tonytangandroid.daggertutorial.QuickTileService;
 
 import dagger.Module;
 import dagger.android.ContributesAndroidInjector;
@@ -11,5 +12,7 @@ public abstract class ServiceInjector {
     @ContributesAndroidInjector()
     abstract DemoService bindDemoService();
 
+    @ContributesAndroidInjector()
+    abstract QuickTileService bindQuickTileService();
 
 }


### PR DESCRIPTION
Add a tile service which only exists in Android 24 or later to demonstrate a potential problem in Dagger, which will crash the app on start if it runs devices with Android API below 24. For details, please refer to this issue in Dagger https://github.com/google/dagger/issues/1064