### PR TITLE
Fix the crash at app start on device with Android Api below 24.

### DIFF
--- a/app/src/main/java/com/github/tonytangandroid/daggertutorial/QuickTileService.java
+++ b/app/src/main/java/com/github/tonytangandroid/daggertutorial/QuickTileService.java
@@ -7,7 +7,6 @@ import android.widget.Toast;
 
 import javax.inject.Inject;
 
-import dagger.android.AndroidInjection;
 import timber.log.Timber;
 
 /**
@@ -22,7 +21,7 @@ public class QuickTileService extends TileService {
     @Override
     public void onCreate() {
         super.onCreate();
-        AndroidInjection.inject(this);
+        ((TutorialApplication) getApplication()).api24OrGreaterServiceInjector().inject(this);
     }
 
     @Override

--- a/app/src/main/java/com/github/tonytangandroid/daggertutorial/TutorialApplication.java
+++ b/app/src/main/java/com/github/tonytangandroid/daggertutorial/TutorialApplication.java
@@ -4,7 +4,9 @@ import android.app.Activity;
 import android.app.Application;
 import android.app.Service;
 
+import com.github.tonytangandroid.daggertutorial.dagger.ApplicationComponent;
 import com.github.tonytangandroid.daggertutorial.dagger.DaggerApplicationComponent;
+import com.github.tonytangandroid.daggertutorial.dagger.api24.HasApi24OrGreaterServiceInjector;
 
 import javax.inject.Inject;
 
@@ -14,18 +16,20 @@ import dagger.android.HasActivityInjector;
 import dagger.android.HasServiceInjector;
 import timber.log.Timber;
 
-public class TutorialApplication extends Application implements HasActivityInjector, HasServiceInjector {
+public class TutorialApplication extends Application implements HasActivityInjector, HasServiceInjector, HasApi24OrGreaterServiceInjector {
 
     @Inject
     DispatchingAndroidInjector<Activity> activityDispatchingAndroidInjector;
     @Inject
     DispatchingAndroidInjector<Service> serviceDispatchingAndroidInjector;
 
+    private ApplicationComponent applicationComponent;
 
     @Override
     public void onCreate() {
         super.onCreate();
-        DaggerApplicationComponent.builder().application(this).build().inject(this);
+        applicationComponent = DaggerApplicationComponent.builder().application(this).build();
+        applicationComponent.inject(this);
         Timber.plant(new Timber.DebugTree());
     }
 
@@ -37,5 +41,10 @@ public class TutorialApplication extends Application implements HasActivityInjec
     @Override
     public AndroidInjector<Service> serviceInjector() {
         return serviceDispatchingAndroidInjector;
+    }
+
+    @Override
+    public AndroidInjector<Service> api24OrGreaterServiceInjector() {
+        return applicationComponent.api24OrGreaterServiceComponent().injector();
     }
 }

--- a/app/src/main/java/com/github/tonytangandroid/daggertutorial/dagger/ApplicationComponent.java
+++ b/app/src/main/java/com/github/tonytangandroid/daggertutorial/dagger/ApplicationComponent.java
@@ -3,6 +3,7 @@ package com.github.tonytangandroid.daggertutorial.dagger;
 import android.app.Application;
 
 import com.github.tonytangandroid.daggertutorial.TutorialApplication;
+import com.github.tonytangandroid.daggertutorial.dagger.api24.Api24OrGreaterServiceComponent;
 import com.github.tonytangandroid.daggertutorial.dagger.module.ApplicationModule;
 import com.github.tonytangandroid.daggertutorial.dagger.module.DataBindModule;
 import com.github.tonytangandroid.daggertutorial.dagger.module.DataProviderModule;
@@ -19,6 +20,8 @@ import dagger.android.AndroidInjectionModule;
         DataProviderModule.class, DataBindModule.class,
         AndroidInjectionModule.class, ActivityInjector.class, ServiceInjector.class})
 public interface ApplicationComponent {
+
+    Api24OrGreaterServiceComponent api24OrGreaterServiceComponent();
 
     void inject(TutorialApplication app);
 

--- a/app/src/main/java/com/github/tonytangandroid/daggertutorial/dagger/ServiceInjector.java
+++ b/app/src/main/java/com/github/tonytangandroid/daggertutorial/dagger/ServiceInjector.java
@@ -1,7 +1,6 @@
 package com.github.tonytangandroid.daggertutorial.dagger;
 
 import com.github.tonytangandroid.daggertutorial.DemoService;
-import com.github.tonytangandroid.daggertutorial.QuickTileService;
 
 import dagger.Module;
 import dagger.android.ContributesAndroidInjector;
@@ -11,8 +10,5 @@ public abstract class ServiceInjector {
 
     @ContributesAndroidInjector()
     abstract DemoService bindDemoService();
-
-    @ContributesAndroidInjector()
-    abstract QuickTileService bindQuickTileService();
 
 }

--- a/app/src/main/java/com/github/tonytangandroid/daggertutorial/dagger/api24/Api24OrGreaterServiceComponent.java
+++ b/app/src/main/java/com/github/tonytangandroid/daggertutorial/dagger/api24/Api24OrGreaterServiceComponent.java
@@ -1,0 +1,11 @@
+package com.github.tonytangandroid.daggertutorial.dagger.api24;
+
+import android.app.Service;
+
+import dagger.Subcomponent;
+import dagger.android.DispatchingAndroidInjector;
+
+@Subcomponent(modules = Api24OrGreaterServiceModule.class)
+public interface Api24OrGreaterServiceComponent {
+    DispatchingAndroidInjector<Service> injector();
+}

--- a/app/src/main/java/com/github/tonytangandroid/daggertutorial/dagger/api24/Api24OrGreaterServiceModule.java
+++ b/app/src/main/java/com/github/tonytangandroid/daggertutorial/dagger/api24/Api24OrGreaterServiceModule.java
@@ -1,0 +1,14 @@
+package com.github.tonytangandroid.daggertutorial.dagger.api24;
+
+import com.github.tonytangandroid.daggertutorial.QuickTileService;
+
+import dagger.Module;
+import dagger.android.ContributesAndroidInjector;
+
+@Module
+public abstract class Api24OrGreaterServiceModule {
+
+    @ContributesAndroidInjector()
+    abstract QuickTileService bindQuickTileService();
+
+}

--- a/app/src/main/java/com/github/tonytangandroid/daggertutorial/dagger/api24/HasApi24OrGreaterServiceInjector.java
+++ b/app/src/main/java/com/github/tonytangandroid/daggertutorial/dagger/api24/HasApi24OrGreaterServiceInjector.java
@@ -1,0 +1,10 @@
+package com.github.tonytangandroid.daggertutorial.dagger.api24;
+
+import android.app.Service;
+
+import dagger.android.AndroidInjector;
+
+public interface HasApi24OrGreaterServiceInjector {
+
+  AndroidInjector<Service> api24OrGreaterServiceInjector();
+}


### PR DESCRIPTION
Fix the crash at app start on device with Android Api below 24 due to the TileService error. This could serve as an example to delay the preparation of initialization until the injected class is being called.